### PR TITLE
feat: add proxy support to OAuth sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnc"
-version = "1.1.6a0"
+version = "1.1.7a0"
 description = "Python SNC (REST) API"
 authors = ["Matthew Gill <matthew.gill@servicenow.com>"]
 license = "MIT"

--- a/pysnc/auth.py
+++ b/pysnc/auth.py
@@ -36,7 +36,7 @@ class ServiceNowPasswordGrantFlow(ServiceNowFlow):
     def authorization_url(self, authorization_base_url):
         return f"{authorization_base_url}/oauth_token.do"
 
-    def authenticate(self, instance: str) -> requests.Session:
+    def authenticate(self, instance: str, proxies: dict) -> requests.Session:
         """
         Designed to be called by ServiceNowClient - internal method.
         """
@@ -49,7 +49,7 @@ class ServiceNowPasswordGrantFlow(ServiceNowFlow):
                                   auto_refresh_kwargs=dict(client_id=self.client_id, client_secret=self.__secret))
             oauth.fetch_token(token_url=self.authorization_url(instance),
                               username=self.__username, password=self.__password, client_id=self.client_id,
-                              client_secret=self.__secret)
+                              client_secret=self.__secret, proxies=proxies)
             self.__password = None  # no longer need this.
             return oauth
         except ImportError:

--- a/pysnc/client.py
+++ b/pysnc/client.py
@@ -62,7 +62,7 @@ class ServiceNowClient(object):
             self.__session.cert = cert
         else:
             raise AuthenticationException('No valid authentication method provided')
-        
+
         if proxy:
             self.__session.proxies = self.__proxies
 

--- a/pysnc/client.py
+++ b/pysnc/client.py
@@ -33,6 +33,15 @@ class ServiceNowClient(object):
         self._log = logging.getLogger(__name__)
         self.__instance = get_instance(instance)
 
+        if proxy:
+            if type(proxy) != dict:
+                proxies = dict(http=proxy, https=proxy)
+            else:
+                proxies = proxy
+            self.__proxies = proxies
+            if verify is None:
+                verify = True  # default to verify with proxy
+
         if auth is not None and cert is not None:
             raise AuthenticationException('Cannot specify both auth and cert')
         elif isinstance(auth, (list, tuple)) and len(auth) == 2:
@@ -48,20 +57,15 @@ class ServiceNowClient(object):
             # maybe we've got an oauth token? Let this be permissive
             self.__session = auth
         elif isinstance(auth, ServiceNowFlow):
-            self.__session = auth.authenticate(self.__instance)
+            self.__session = auth.authenticate(self.__instance, self.__proxies)
         elif cert is not None:
             self.__session.cert = cert
         else:
             raise AuthenticationException('No valid authentication method provided')
-
+        
         if proxy:
-            if type(proxy) != dict:
-                proxies = dict(http=proxy, https=proxy)
-            else:
-                proxies = proxy
-            self.__session.proxies = proxies
-            if verify is None:
-                verify = True  # default to verify with proxy
+            self.__session.proxies = self.__proxies
+
         if verify is not None:
             self.__session.verify = verify
 


### PR DESCRIPTION
Hi there, 

Just an issue that we came into, the proxy or proxies given to the ServiceNowClient are currently not used when authenticating using OAuth, which breaks everything in our use case. 

The refactor might not be the cleanest, but works as expected in our environment now. Feel free to request any modification on my side to make it fit your requirements. 

Cheers.