### PR TITLE
feat: Add a link  to Glide Element when available

### DIFF
--- a/pysnc/client.py
+++ b/pysnc/client.py
@@ -148,7 +148,8 @@ class API(object):
         params = {} if record is None else record._parameters()
         if 'sysparm_display_value' not in params:
             params['sysparm_display_value'] = 'all'
-        params['sysparm_exclude_reference_link'] = 'true'  # Scratch it!
+        if 'sysparm_exclude_reference_link' not in params:
+            params['sysparm_exclude_reference_link'] = 'true'  # Scratch it!, by default
         params['sysparm_suppress_pagination_header'] = 'true'  # Required for large queries
         return params
 

--- a/pysnc/record.py
+++ b/pysnc/record.py
@@ -823,7 +823,7 @@ class GlideRecord(object):
         else:
             c[field].set_link(value)
 
-    def get_link(self, no_stack=False, field=None) -> str:
+    def get_link(self, no_stack=False) -> str:
         """
         Generate a full URL to the current record. sys_id will be null if there is no current record.
 
@@ -832,16 +832,13 @@ class GlideRecord(object):
         :return: The full URL to the current record
         :rtype: str
         """
-        if field is not None:
-            return self._get_value(field, 'link')
-        else:
-            ins = self._client.instance
-            obj = self._current()
-            stack = '&sysparm_stack=%s_list.do?sysparm_query=active=true' % self.__table
-            if no_stack:
-                stack = ''
-            id = self.sys_id if obj else 'null'
-            return "{}/{}.do?sys_id={}{}".format(ins, self.__table, id, stack)
+        ins = self._client.instance
+        obj = self._current()
+        stack = '&sysparm_stack=%s_list.do?sysparm_query=active=true' % self.__table
+        if no_stack:
+            stack = ''
+        id = self.sys_id if obj else 'null'
+        return "{}/{}.do?sys_id={}{}".format(ins, self.__table, id, stack)
 
     def get_link_list(self) -> Optional[str]:
         """

--- a/test/test_snc_element.py
+++ b/test/test_snc_element.py
@@ -116,6 +116,23 @@ class TestElement(TestCase):
         self.assertEqual(json.dumps(gr2.serialize(display_value=True)), '{"two_field": "Some Value"}')
         self.assertEqual(gr2.two_field.get_name(), 'two_field')
 
+    def test_serialization_with_link(self):
+        gr = GlideRecord(None, 'incident')
+        gr.initialize()
+        gr.test_field = 'some string'
+        self.assertTrue(isinstance(gr.test_field, GlideElement))
+        r = gr.serialize()
+        self.assertEqual(json.dumps(r), '{"test_field": "some string"}')
+
+        gr.set_value('test_field', 'somevalue')
+        gr.set_display_value('test_field', 'Some Value')
+        gr.set_link('test_field', 'https://dev00000.service-now.com/api/now/table/sys___/abcde12345')
+        print(gr.serialize())
+        self.assertEqual(json.dumps(gr.serialize()), '{"test_field": "somevalue"}')
+        self.assertEqual(json.dumps(gr.serialize(display_value=True, exclude_reference_link=False)), '{"test_field": {"display_value": "Some Value", "link": "https://dev00000.service-now.com/api/now/table/sys___/abcde12345"}}')
+        self.assertEqual(json.dumps(gr.serialize(display_value=False, exclude_reference_link=False)), '{"test_field": {"value": "somevalue", "link": "https://dev00000.service-now.com/api/now/table/sys___/abcde12345"}}')
+        self.assertEqual(json.dumps(gr.serialize(display_value='both', exclude_reference_link=False)), '{"test_field": {"value": "somevalue", "display_value": "Some Value", "link": "https://dev00000.service-now.com/api/now/table/sys___/abcde12345"}}')
+
     def test_set_element(self):
         element = GlideElement('state', '3', 'Pending Change')
 

--- a/test/test_snc_serialization.py
+++ b/test/test_snc_serialization.py
@@ -158,6 +158,37 @@ class TestSerialization(TestCase):
         self.assertEqual(data, {'intfield': 5, 'strfield': 'my string display value'})
         client.session.close()
 
+    def test_serialize_reference_link(self):
+        client = ServiceNowClient(self.c.server, self.c.credentials)
+        gr = client.GlideRecord('some_table')
+        gr.initialize()
+        gr.reffield = 'my reference'
+        gr.set_link('reffield', 'https://dev00000.service-now.com/api/now/table/sys___/abcde12345')
+        
+        data = gr.serialize(exclude_reference_link=False)
+        self.assertIsNotNone(data)
+        self.assertEqual(gr.get_value('reffield'), 'my reference')
+        self.assertEqual(gr.get_link('reffield'), 'https://dev00000.service-now.com/api/now/table/sys___/abcde12345')
+        self.assertEqual(gr.serialize(exclude_reference_link=False), {'reffield':{'value': 'my reference','link':'https://dev00000.service-now.com/api/now/table/sys___/abcde12345'}})
+        self.assertEqual(data, {'reffield':{'value': 'my reference','link':'https://dev00000.service-now.com/api/now/table/sys___/abcde12345'}})
+        client.session.close()
+
+    def test_serialize_reference_link_all(self):
+        client = ServiceNowClient(self.c.server, self.c.credentials)
+        gr = client.GlideRecord('some_table')
+        gr.initialize()
+        gr.reffield = 'my reference'
+        gr.set_link('reffield', 'https://dev00000.service-now.com/api/now/table/sys___/abcde12345')
+        gr.set_display_value('reffield', 'my reference display')
+
+        data = gr.serialize(exclude_reference_link=False)
+        self.assertIsNotNone(data)
+        self.assertEqual(gr.get_value('reffield'), 'my reference')
+        self.assertEqual(gr.get_link('reffield'), 'https://dev00000.service-now.com/api/now/table/sys___/abcde12345')
+        self.assertEqual(gr.serialize(exclude_reference_link=False), {'reffield':{'value': 'my reference','display_value': 'my reference display', 'link':'https://dev00000.service-now.com/api/now/table/sys___/abcde12345'}})
+        self.assertEqual(data, {'reffield':{'value': 'my reference','display_value': 'my reference display', 'link':'https://dev00000.service-now.com/api/now/table/sys___/abcde12345'}})
+        client.session.close()
+
     def test_str(self):
         client = ServiceNowClient(self.c.server, self.c.credentials)
         gr = client.GlideRecord('some_table')


### PR DESCRIPTION
Add a `link` attribute to Glide Elements that contain one.  By default, the API should function as it did before and ignore the `link` field entirely.  This was a little more involved than originally anticipated mostly due to how serialization works.

A new (optional) parameter `exclude_reference_link` was added to allow links to be excluded (default) or included (new)
(see: https://docs.servicenow.com/bundle/xanadu-api-reference/page/integrate/inbound-rest/concept/c_TableAPI.html#d230634e1380)

NOTE: I did include some additional tests however I do not have a server to test this against so it's minimal at best.