### PR TITLE
fix serialize all to use keyword arguments

### DIFF
--- a/pysnc/record.py
+++ b/pysnc/record.py
@@ -31,9 +31,10 @@ class GlideElement(str):
         self._changed = False
         self._link = None
         if isinstance(value, dict):
-            self._value = value['value']
+            if 'value' in value:
+                self._value = value['value']
             # only bother to set display value if it's different
-            if self._value != value['display_value']:
+            if 'display_value' in value and self._value != value['display_value']:
                 self._display_value = value['display_value']
             if 'link' in value:
                 self._link = value['link']
@@ -1090,7 +1091,7 @@ class GlideRecord(object):
         :param fmt:
         :return: list
         """
-        return [record.serialize(display_value, fields, fmt, exclude_reference_link) for record in self]
+        return [record.serialize(display_value=display_value, fields=fields, fmd=fmt, exclude_reference_link=exclude_reference_link) for record in self]
 
     def to_pandas(self, columns=None, mode='smart'):
         """


### PR DESCRIPTION
As described in #121, uses keyword arguments when calling serialize on each record.  I could also add the additional changes only argument if you think it's worth doing, but keyword arguments do seems to make sense here regardless.

I also noticed that if you set `display_value=True` and the value is a dictionary (e.g. contains a link) then it will not contain a `value` attribute.  So put a quick check to ensure value does in fact exist before moving forward.